### PR TITLE
Upgrade connect-mongo.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mongodb:
-        image: mongo:3.6
+        image: mongo:4.2
         ports:
           - 27017:27017
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # bedrock-session-mongodb ChangeLog
 
+## 4.0.0 -
+
+### Changed
+  - **BREAKING**: Upgrade `bedrock-mongodb` to ^7.0.0.
+  - **BREAKING**: Change dbPromise to clientPromise.
+  - **BREAKING**: Upgrade `connect-mongo` to ^3.2.0.
+
+### Added
+  - Add a test for basic functionality.
+
 ## 3.1.0 - 2019-11-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Changed
 - **BREAKING**: Upgrade `bedrock-mongodb` to ^7.0.0.
-- **BREAKING**: Change dbPromise to clientPromise.
 - **BREAKING**: Upgrade `connect-mongo` to ^3.2.0.
+- Change dbPromise to clientPromise for `connect-mongo`.
 
 ### Added
 - Add a test for basic functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ## 4.0.0 -
 
 ### Changed
-  - **BREAKING**: Upgrade `bedrock-mongodb` to ^7.0.0.
-  - **BREAKING**: Change dbPromise to clientPromise.
-  - **BREAKING**: Upgrade `connect-mongo` to ^3.2.0.
+- **BREAKING**: Upgrade `bedrock-mongodb` to ^7.0.0.
+- **BREAKING**: Change dbPromise to clientPromise.
+- **BREAKING**: Upgrade `connect-mongo` to ^3.2.0.
 
 ### Added
-  - Add a test for basic functionality.
+- Add a test for basic functionality.
 
 ## 3.1.0 - 2019-11-08
 

--- a/lib/sessionStore.js
+++ b/lib/sessionStore.js
@@ -14,7 +14,7 @@ const {promisify} = require('util');
 // load config defaults
 require('./config');
 
-const dbPromise = new Promise(function(resolve) {
+const clientPromise = new Promise(function(resolve) {
   bedrock.events.on('bedrock-mongodb.ready', function() {
     resolve(database.client);
   });
@@ -32,7 +32,7 @@ bedrock.events.on('bedrock-express.configure.session', function(app) {
     MongoStore = connectMongo(app.express);
   }
   const store = new MongoStore({
-    dbPromise,
+    clientPromise,
     collection: bedrock.config['session-mongodb'].collection,
     ttl: bedrock.config['session-mongodb'].ttl
   });

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-session-mongodb",
   "dependencies": {
-    "connect-mongo": "^2.0.1"
+    "connect-mongo": "^3.2.0"
   },
   "peerDependencies": {
     "bedrock": "1.0.0 - 3.x",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "bedrock": "1.0.0 - 3.x",
     "bedrock-express": "2.0.3 - 3.x",
-    "bedrock-mongodb": "3.x - 6.x"
+    "bedrock-mongodb": "^7.0.0"
   },
   "directories": {
     "lib": "./lib"

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -2,7 +2,21 @@
  * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
+const bedrock = require('bedrock');
+const {config} = bedrock;
 
-describe('session-mongodb API', () => {
-  it('should work');
+describe('session-mongodb API', function() {
+  let store;
+  before(function() {
+    store = config.express.session.store;
+  });
+  it('should create a session store', async function() {
+    should.exist(store);
+    store.should.be.an('object');
+    should.exist(store.state);
+    store.state.should.be.a('string');
+    store.state.should.equal('connected');
+    should.exist(store.db);
+    should.exist(store.client);
+  });
 }); // end session-mongodb API

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bedrock": "^3.1.0",
     "bedrock-express": "^3.1.0",
-    "bedrock-mongodb": "^6.0.2",
+    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
     "bedrock-server": "^2.4.1",
     "bedrock-session-mongodb": "file:..",
     "bedrock-test": "^5.1.0",

--- a/test/package.json
+++ b/test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bedrock": "^3.1.0",
     "bedrock-express": "^3.1.0",
-    "bedrock-mongodb": "digitalbazaar/bedrock-mongodb#driver3",
+    "bedrock-mongodb": "^7.0.0",
     "bedrock-server": "^2.4.1",
     "bedrock-session-mongodb": "file:..",
     "bedrock-test": "^5.1.0",

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -13,3 +13,8 @@ config.mongodb.name = 'bedrock_session_mongodb_test';
 config.mongodb.dropCollections = {};
 config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
+
+// Session Settings
+config.express.session.secret = 'NOTASECRET';
+config.express.session.key = 'test-node.sid';
+config.express.session.prefix = 'test-node.';


### PR DESCRIPTION
This depends on the next version of `bedrock-mongodb` being released.
All that is needed so far is upgrading `connect-mongo` and changing one parameter for the `MongoStore` contructor.

Addresses:

https://github.com/digitalbazaar/bedrock-session-mongodb/issues/7


THIS IS A BREAKING RELEASE.

This was tested with mongodb version `4.2.7` and the sessions did save.