### PR TITLE
Bump peerdep for bedrock-mongodb.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "bedrock": "1.0.0 - 3.x",
     "bedrock-express": "2.0.3 - 3.x",
-    "bedrock-mongodb": "^7.1.0"
+    "bedrock-mongodb": "7.x - 8.x"
   },
   "directories": {
     "lib": "./lib"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lib": "./lib"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-digitalbazaar": "^2.3.0"
+    "eslint": "^7.13.0",
+    "eslint-config-digitalbazaar": "^2.6.1"
   }
 }


### PR DESCRIPTION
Extremely minor update: bumps `bedrock-mongodb` peerDep. This can wait for the next release.
Also bumps `eslint` and `eslint-config-digitalbazaar`